### PR TITLE
107 version3 seperate mongodb envs to prod and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ commit and push often.
 
 ## How to connect to MongoDB and run the server locally 
 - in harmony repository, go to '/harmony/server/config' and create a 'config.env' file.
-- the 'config.env' file should contain the development environment, the port (on which the server runs locally) and the Mongo URI, as following:
-    NODE_ENV=development 
+- the 'config.env' file should contain the development environment, the port (on which the server runs locally) and the Mongo URI for each one of the development environments, as following:
+    NODE_ENV=development or NODE_ENV=production
     PORT=5000
-    MONGO_URI=mongodb+srv://<your username>:<your password>@harmony.btro83c.mongodb.net/
+    MONGO_URI_DEV=mongodb+srv://<your username>:<your password>@harmony.btro83c.mongodb.net/
+    MONGO_URI_PROD=mongodb+srv://<your username>:<your password>@harmony.abcd12e.mongodb.net/
 - to run the server, write one of the following commands in the terminal:
     1. To start the server normally: node server.js
     2. To run with nodemon, make sure you have nodemon installed and run: npm run server.js

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -2,10 +2,18 @@ import mongoose from "mongoose";
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGO_URI, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    let conn
+    if (process.env.NODE_ENV === "development"){
+      conn = await mongoose.connect(process.env.MONGO_URI_DEV, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+      });
+    } else if (process.env.NODE_ENV === "production"){
+      conn = await mongoose.connect(process.env.MONGO_URI_PROD, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+      });
+    }
     console.log(`Mongo Connected: ${conn.connection.host}`);
   } catch (error) {
     console.error(`${error}`);

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -13,6 +13,8 @@ const connectDB = async () => {
         useNewUrlParser: true,
         useUnifiedTopology: true,
       });
+    } else {
+      throw new Error("Invalid NODE_ENV specified");
     }
     console.log(`Mongo Connected: ${conn.connection.host}`);
   } catch (error) {

--- a/server/scripts/config.script.sh
+++ b/server/scripts/config.script.sh
@@ -10,7 +10,7 @@ else
   touch "$CONFIG_DIR/config.env"
 
   # Define an array of environment variable names
-  declare -a variables=("PORT" "NODE_ENV" "MONGO_URI" "OPEN_AI_API_KEY")
+  declare -a variables=("PORT" "NODE_ENV" "MONGO_URI_DEV" "MONGO_URI_PROD" "OPEN_AI_API_KEY")
 
   # Loop over the array and prompt the user to enter values for each variable
   for variable in "${variables[@]}"


### PR DESCRIPTION
-created a new Atlas instance for production 
- connected the db in the function 'db.js', so if the development environment 'production' it connects to the production db, if 'development' it connects to the development db.
- updated readme file with the change
- updated config.script.sh with the change

->> Everywhere in the app, where the MONGO_URI appeared, updated to MONGO_URI_DEV or MONGO_URI_PROD